### PR TITLE
collect and raise rc of ssh-keygen if non-zero

### DIFF
--- a/lib/puppet/parser/functions/ssh_keygen.rb
+++ b/lib/puppet/parser/functions/ssh_keygen.rb
@@ -33,6 +33,10 @@ module Puppet::Parser::Functions
     begin
       unless File.exists?("#{config[:basedir]}/#{config[:ssh_dir]}/#{config[:ssh_comment]}") then
         %x[/usr/bin/ssh-keygen -t #{config[:ssh_key_type]} -P '' -f #{config[:basedir]}/#{config[:ssh_dir]}/#{config[:ssh_comment]}]
+        rc = $?
+        unless rc == 0
+          raise "ssh-keygen return code is #{rc}"
+        end
       end
     rescue => e
       raise Puppet::ParseError, "ssh_keygen(): Unable to generate ssh key (#{e})"


### PR DESCRIPTION
%x[] does not raise an exception if the return code is non-zero. This must be done explicitly.
